### PR TITLE
Allow capital raise withdrawal to use restricted marker

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.61.0-x86_64-unknown-linux-gnu
+          toolchain: 1.67.0-x86_64-unknown-linux-gnu
           default: true
           components: clippy, rustfmt
       - name: cargo format

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,26 +1,26 @@
+use cosmwasm_std::to_binary;
+use cosmwasm_std::WasmMsg;
+use cosmwasm_std::{
+    coins, entry_point, Addr, Attribute, BankMsg, CosmosMsg, DepsMut, Env, Event, MessageInfo,
+    Reply, Response, SubMsgResult,
+};
+use provwasm_std::ProvenanceQuery;
+use provwasm_std::{transfer_marker_coins, MarkerType, ProvenanceMsg, ProvenanceQuerier};
+use serde::Serialize;
+
 use crate::error::contract_error;
+use crate::error::ContractError;
 use crate::exchange_asset::try_cancel_asset_exchanges;
 use crate::exchange_asset::try_complete_asset_exchange;
 use crate::exchange_asset::try_issue_asset_exchanges;
+use crate::msg::HandleMsg;
+use crate::state::config;
 use crate::state::eligible_subscriptions;
 use crate::state::pending_subscriptions;
 use crate::subscribe::try_accept_subscriptions;
 use crate::subscribe::try_close_subscriptions;
 use crate::subscribe::try_propose_subscription;
 use crate::subscribe::try_upgrade_eligible_subscriptions;
-use cosmwasm_std::to_binary;
-use cosmwasm_std::WasmMsg;
-use cosmwasm_std::{
-    coins, entry_point, Addr, Attribute, BankMsg, DepsMut, Env, Event, MessageInfo, Reply,
-    Response, SubMsgResult,
-};
-use provwasm_std::ProvenanceMsg;
-use provwasm_std::ProvenanceQuery;
-use serde::Serialize;
-
-use crate::error::ContractError;
-use crate::msg::HandleMsg;
-use crate::state::config;
 
 pub type ContractResponse = Result<Response<ProvenanceMsg>, ContractError>;
 
@@ -137,9 +137,23 @@ pub fn execute(
                 return contract_error("only gp can redeem capital");
             }
 
-            let send = BankMsg::Send {
-                to_address: to.to_string(),
-                amount: coins(amount as u128, state.capital_denom),
+            let capital_marker =
+                ProvenanceQuerier::new(&deps.querier).get_marker_by_denom(&state.capital_denom)?;
+
+            let mut bank_send: Option<BankMsg> = None;
+            let mut marker_transfer: Option<CosmosMsg<ProvenanceMsg>> = None;
+            if capital_marker.marker_type == MarkerType::Coin {
+                bank_send = Some(BankMsg::Send {
+                    to_address: to.to_string(),
+                    amount: coins(amount as u128, &state.capital_denom),
+                });
+            } else {
+                marker_transfer = Some(transfer_marker_coins(
+                    amount as u128,
+                    &state.capital_denom,
+                    to,
+                    env.contract.address,
+                )?)
             };
 
             let attributes = match memo {
@@ -152,24 +166,65 @@ pub fn execute(
                 None => vec![],
             };
 
-            Ok(Response::new().add_message(send).add_attributes(attributes))
+            let response;
+            if let Some(bank_send_msg) = bank_send {
+                response = Response::new()
+                    .add_message(bank_send_msg)
+                    .add_attributes(attributes);
+            } else {
+                response = Response::new()
+                    .add_message(marker_transfer.unwrap())
+                    .add_attributes(attributes);
+            }
+            Ok(response)
         }
     }
 }
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
-    use crate::mock::msg_at_index;
+    use cosmwasm_std::testing::{mock_env, mock_info, MockApi, MockStorage, MOCK_CONTRACT_ADDR};
+    use cosmwasm_std::{coin, SubMsgResponse};
+    use cosmwasm_std::{Addr, OwnedDeps};
+    use provwasm_mocks::{mock_dependencies, ProvenanceMockQuerier};
+    use provwasm_std::MarkerMsgParams;
+
     use crate::mock::send_args;
+    use crate::mock::{load_markers, marker_transfer_msg, msg_at_index};
     use crate::state::config_read;
     use crate::state::eligible_subscriptions_read;
     use crate::state::pending_subscriptions_read;
     use crate::state::State;
-    use cosmwasm_std::testing::{mock_env, mock_info, MockApi, MockStorage};
-    use cosmwasm_std::SubMsgResponse;
-    use cosmwasm_std::{Addr, OwnedDeps};
-    use provwasm_mocks::{mock_dependencies, ProvenanceMockQuerier};
+
+    use super::*;
+
+    impl State {
+        pub fn test_capital_coin() -> State {
+            State {
+                subscription_code_id: 100,
+                recovery_admin: Addr::unchecked("marketpalace"),
+                gp: Addr::unchecked("gp"),
+                required_attestations: vec![vec![String::from("506c")].into_iter().collect()],
+                commitment_denom: String::from("commitment_coin"),
+                investment_denom: String::from("investment_coin"),
+                capital_denom: String::from("capital_coin"),
+                capital_per_share: 100,
+            }
+        }
+
+        pub fn test_restricted_capital_coin() -> State {
+            State {
+                subscription_code_id: 100,
+                recovery_admin: Addr::unchecked("marketpalace"),
+                gp: Addr::unchecked("gp"),
+                required_attestations: vec![vec![String::from("506c")].into_iter().collect()],
+                commitment_denom: String::from("commitment_coin"),
+                investment_denom: String::from("investment_coin"),
+                capital_denom: String::from("restricted_capital_coin"),
+                capital_per_share: 100,
+            }
+        }
+    }
 
     pub fn default_deps(
         update_state: Option<fn(&mut State)>,
@@ -177,6 +232,34 @@ pub mod tests {
         let mut deps = mock_dependencies(&[]);
 
         let mut state = State::test_default();
+        if let Some(update) = update_state {
+            update(&mut state);
+        }
+        config(&mut deps.storage).save(&state).unwrap();
+
+        deps
+    }
+
+    pub fn capital_coin_deps(
+        update_state: Option<fn(&mut State)>,
+    ) -> OwnedDeps<MockStorage, MockApi, ProvenanceMockQuerier, ProvenanceQuery> {
+        let mut deps = mock_dependencies(&[]);
+
+        let mut state = State::test_capital_coin();
+        if let Some(update) = update_state {
+            update(&mut state);
+        }
+        config(&mut deps.storage).save(&state).unwrap();
+
+        deps
+    }
+
+    pub fn restricted_capital_coin_deps(
+        update_state: Option<fn(&mut State)>,
+    ) -> OwnedDeps<MockStorage, MockApi, ProvenanceMockQuerier, ProvenanceQuery> {
+        let mut deps = mock_dependencies(&[]);
+
+        let mut state = State::test_restricted_capital_coin();
         if let Some(update) = update_state {
             update(&mut state);
         }
@@ -308,7 +391,8 @@ pub mod tests {
 
     #[test]
     fn issue_withdrawal() {
-        let mut deps = default_deps(None);
+        let mut deps = capital_coin_deps(None);
+        load_markers(&mut deps.querier);
 
         let res = execute(
             deps.as_mut(),
@@ -327,6 +411,36 @@ pub mod tests {
         let (to_address, coins) = send_args(msg_at_index(&res, 0));
         assert_eq!("omni", to_address);
         assert_eq!(10_000, coins.first().unwrap().amount.u128());
+    }
+
+    #[test]
+    fn issue_restricted_coin_withdrawal() {
+        let mut deps = restricted_capital_coin_deps(None);
+        load_markers(&mut deps.querier);
+
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("gp", &[]),
+            HandleMsg::IssueWithdrawal {
+                to: Addr::unchecked("omni"),
+                amount: 10_000,
+                memo: None,
+            },
+        )
+        .unwrap();
+
+        // verify that send message is sent
+        assert_eq!(1, res.messages.len());
+        println!("{:?}", msg_at_index(&res, 0));
+        assert_eq!(
+            &MarkerMsgParams::TransferMarkerCoins {
+                coin: coin(10_000, "restricted_capital_coin"),
+                to: Addr::unchecked("omni"),
+                from: Addr::unchecked(MOCK_CONTRACT_ADDR),
+            },
+            marker_transfer_msg(msg_at_index(&res, 0)),
+        );
     }
 
     #[test]

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::BankMsg;
 use cosmwasm_std::CosmosMsg;
@@ -8,14 +10,12 @@ use cosmwasm_std::{
     from_slice, Binary, Coin, ContractResult, OwnedDeps, Querier, QueryRequest, SystemError,
     SystemResult, WasmQuery,
 };
+use provwasm_mocks::{must_read_binary_file, ProvenanceMockQuerier};
 use provwasm_std::ProvenanceMsg;
 use provwasm_std::ProvenanceMsgParams;
+use provwasm_std::ProvenanceQuery;
 use provwasm_std::{Marker, MarkerMsgParams};
 use serde::de::DeserializeOwned;
-use std::marker::PhantomData;
-
-use provwasm_mocks::{must_read_binary_file, ProvenanceMockQuerier};
-use provwasm_std::ProvenanceQuery;
 
 pub type MockWasmSmartHandler = fn(String, Binary) -> SystemResult<ContractResult<Binary>>;
 pub type MockBankBalanceHandler = fn(String, String) -> SystemResult<ContractResult<Binary>>;
@@ -87,6 +87,22 @@ pub fn marker_msg(msg: &CosmosMsg<ProvenanceMsg>) -> &MarkerMsgParams {
     if let CosmosMsg::Custom(msg) = msg {
         if let ProvenanceMsgParams::Marker(params) = &msg.params {
             params
+        } else {
+            panic!("not a marker message!")
+        }
+    } else {
+        panic!("not a cosmos custom message!")
+    }
+}
+
+pub fn marker_transfer_msg(msg: &CosmosMsg<ProvenanceMsg>) -> &MarkerMsgParams {
+    if let CosmosMsg::Custom(msg) = msg {
+        if let ProvenanceMsgParams::Marker(params) = &msg.params {
+            if let MarkerMsgParams::TransferMarkerCoins { coin, to, from } = params {
+                params
+            } else {
+                panic!("not a marker transfer message!")
+            }
         } else {
             panic!("not a marker message!")
         }
@@ -170,5 +186,10 @@ pub fn load_markers(querier: &mut ProvenanceMockQuerier) {
         from_binary(&bin).unwrap()
     };
 
-    querier.with_markers(vec![get_marker("commitment"), get_marker("investment")]);
+    querier.with_markers(vec![
+        get_marker("commitment"),
+        get_marker("investment"),
+        get_marker("capital_coin"),
+        get_marker("restricted_capital_coin"),
+    ]);
 }

--- a/src/subscribe.rs
+++ b/src/subscribe.rs
@@ -45,7 +45,7 @@ pub fn try_propose_subscription(
 
     Ok(Response::new()
         .add_submessage(create_sub)
-        .add_attribute("eligible", format!("{}", eligible)))
+        .add_attribute("eligible", format!("{eligible}")))
 }
 
 pub fn try_close_subscriptions(

--- a/testdata/capital_coin_marker.json
+++ b/testdata/capital_coin_marker.json
@@ -1,0 +1,30 @@
+{
+    "address": "tp1v5st64kzeuddsqkderddprpkg5upce4xuwdhdl",
+    "coins": [
+      {
+        "denom": "capital_coin",
+        "amount": "420"
+      }
+    ],
+    "public_key": "",
+    "account_number": 10,
+    "sequence": 0,
+    "permissions": [
+      {
+        "permissions": [
+          "burn",
+          "delete",
+          "deposit",
+          "admin",
+          "mint",
+          "withdraw"
+        ],
+        "address": "tp1v5st64kzeuddsqkderddprpkg5upce4xuwdhdl"
+      }
+    ],
+    "status": "active",
+    "denom": "capital_coin",
+    "total_supply": "420",
+    "marker_type": "coin",
+    "supply_fixed": false
+  }

--- a/testdata/restricted_capital_coin_marker.json
+++ b/testdata/restricted_capital_coin_marker.json
@@ -1,0 +1,30 @@
+{
+    "address": "tp19dmdhtyd2x2uzsecdsjdrjjn06pawnj3eas5wk",
+    "coins": [
+      {
+        "denom": "restricted_capital_coin",
+        "amount": "420"
+      }
+    ],
+    "public_key": "",
+    "account_number": 10,
+    "sequence": 0,
+    "permissions": [
+      {
+        "permissions": [
+          "burn",
+          "delete",
+          "deposit",
+          "admin",
+          "mint",
+          "withdraw"
+        ],
+        "address": "tp19dmdhtyd2x2uzsecdsjdrjjn06pawnj3eas5wk"
+      }
+    ],
+    "status": "active",
+    "denom": "restricted_capital_coin",
+    "total_supply": "420",
+    "marker_type": "restricted",
+    "supply_fixed": false
+  }


### PR DESCRIPTION
When using a capital denomination tied to a restricted marker, the capital raise withdrawal needed to use a `marker transfer` instead of a `bank send`. Doing these changes very iteratively so that PR reviews can catch any anti-patterns I may be adopting in Rust.