### PR TITLE
Add Datadog service definition to register applications in the Service Catalog

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -1,0 +1,14 @@
+schema-version: v2
+dd-service: marketpalace-raise-contract
+team: dfs
+contacts:
+- type: slack
+  contact: https://figure-group.slack.com/archives/C01F4UJQ7D2
+repos:
+- name: GitHub Repo
+  provider: github
+  url: https://github.com/FigureTechnologies/marketpalace-raise-contract
+docs:
+- name: GitHub Team
+  provider: github
+  url: https://github.com/orgs/FigureTechnologies/teams/dfs/members


### PR DESCRIPTION
This PR Creates a `service.datadog.yaml` file, which will automatically register this repository and its deployments with the [Datadog Service Catalog](https://app.datadoghq.com/services?env=development&hostGroup=&lens=Ownership). This file is created using the data gathered during our last RAU day.

Information that gets tied to Datadog includes team name and a link to their slack channel. APIs with docs in the Developer Portal will also have an included link.

---

## 📣 Required Action

⚠️ **This PR is missing important information that is required.** ⚠️ Please check the file and fill in the requested data before reviewing and merging this PR!

---

[Link to Notion Blog Post](https://www.notion.so/figuretech/The-Datadog-Service-Catalog-40684e63a81c4293beba7f90f5bc9c4b?pvs=4)

Please see [this shortcut ticket](https://app.shortcut.com/figure/story/208641/create-script-to-correlate-rau-notion-data-with-github-deployment-data?ct_workflow=all&cf_workflow=500089005) for more information.

[sc-208917]
